### PR TITLE
Update to remove bot profile

### DIFF
--- a/roles/genral_onboarding/templates/asm_logging_profile_payload.j2
+++ b/roles/genral_onboarding/templates/asm_logging_profile_payload.j2
@@ -42,21 +42,6 @@
             "servers": [ "{{vault_splunk_addr }}:{{vault_splunk_syslog_port}}" ]
         }
     ],
-	    "botDefense": [
-        {
-            "name": "asm_log_to_splunk",
-            "partition": "Common",
-            "filter": {
-                "logBotSignatureMatchedRequests": "enabled",
-                "logCaptchaChallengedRequests": "enabled",
-                "logChallengedRequests": "enabled",
-                "logIllegalRequests": "enabled",
-                "logLegalRequests": "enabled"
-            },
-            "localPublisher": "/Common/local-db-publisher",
-            "remotePublisher": "/Common/logging-publisher-f5_analytics"
-        }
-    ],
 	    "dosApplication": [
         {
             "name": "asm_log_to_splunk",


### PR DESCRIPTION
removing bot profile from L7ddos profile. 
14.1 separates bot into a new profile and having bot references in L7ddos  causes the build to fail